### PR TITLE
fixed notebook dependency issue

### DIFF
--- a/notebooks/Manifest.toml
+++ b/notebooks/Manifest.toml
@@ -20,7 +20,9 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[AutocorrelationShell]]
 deps = ["DSP", "Documenter", "LinearAlgebra", "Parameters", "Plots", "Random", "Reexport", "SpecialFunctions", "Statistics", "StatsBase", "Wavelets"]
-path = "/Users/shozendan/Documents/autocorrelation-shell"
+git-tree-sha1 = "b4eec094d5b3fec8f536361711554782811a7242"
+repo-rev = "master"
+repo-url = "https://github.com/ShozenD/AutocorrelationShell.jl.git"
 uuid = "69d4c476-349e-11e9-22d5-d17d72ccee3f"
 version = "0.1.1"
 
@@ -65,9 +67,9 @@ version = "0.9.5"
 
 [[ColorSchemes]]
 deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
-git-tree-sha1 = "d3cf83862f70d430d4b34e43ed65e74bd50ae0e0"
+git-tree-sha1 = "9d7dfad1326b1ad29afa1366587806a14d727745"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.11.0"
+version = "3.12.0"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -689,9 +691,9 @@ version = "1.11.2"
 
 [[Pluto]]
 deps = ["Base64", "Dates", "Distributed", "FuzzyCompletions", "HTTP", "InteractiveUtils", "Logging", "Markdown", "MsgPack", "Pkg", "REPL", "Sockets", "TableIOInterface", "Tables", "UUIDs"]
-git-tree-sha1 = "330dce68faaf8614f8e33dd30bc8a3b911845987"
+git-tree-sha1 = "7764c0ad79718a5e5f684b68db7cb069fb60b909"
 uuid = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
-version = "0.14.1"
+version = "0.14.2"
 
 [[PlutoUI]]
 deps = ["Base64", "Dates", "InteractiveUtils", "Logging", "Markdown", "Random", "Suppressor"]
@@ -862,9 +864,9 @@ version = "0.5.1"
 
 [[StructTypes]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "5eaf731e88587bb72a6c1262c0a014cd1859a08d"
+git-tree-sha1 = "63fbaf8345b590161cd0c35b927f88d3f7b2cf75"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-version = "1.5.2"
+version = "1.6.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
@@ -892,9 +894,9 @@ version = "1.0.1"
 
 [[Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "a9ff3dfec713c6677af435d6a6d65f9744feef67"
+git-tree-sha1 = "c9d2d262e9a327be1f35844df25fe4561d258dc9"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.4.1"
+version = "1.4.2"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
@@ -940,8 +942,10 @@ uuid = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 version = "0.9.2"
 
 [[WaveletsExt]]
-deps = ["AverageShiftedHistograms", "LinearAlgebra", "Parameters", "Plots", "Random", "Reexport", "Statistics", "StatsBase", "Wavelets"]
-path = "/Users/shozendan/Documents/WaveletsExt.jl"
+deps = ["AutocorrelationShell", "AverageShiftedHistograms", "LinearAlgebra", "Parameters", "Plots", "Random", "Reexport", "Statistics", "StatsBase", "Wavelets"]
+git-tree-sha1 = "5495a7c76265803d242b0b086eb29eb906770b99"
+repo-rev = "master"
+repo-url = "https://github.com/zengfung/WaveletsExt.jl.git"
 uuid = "8f464e1e-25db-479f-b0a5-b7680379e03f"
 version = "0.1.0"
 

--- a/notebooks/denoising.jl
+++ b/notebooks/denoising.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.14.0
+# v0.14.1
 
 using Markdown
 using InteractiveUtils
@@ -17,6 +17,7 @@ end
 let
     import Pkg
     Pkg.activate(".")
+	Pkg.instantiate()
 end
 
 # ╔═╡ 203fb8c8-4358-4908-b616-a691ce329c02


### PR DESCRIPTION
- notebook dependencies stated on Manifest.toml changed. AutocorrelationShell and WaveletsExt now point to respective Github master branch
- updated Pluto to newest version on Manifest.toml
- added `Pkg.instantiate()` on notebook to instantiate environment for users